### PR TITLE
Pin packages to a specific version

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -7,35 +7,33 @@ dependencies:
   - statsmodels==0.13.2
   - python==3.8
   - pyfiglet==0.8.post1
-  - pip
-  - xarray
-  - pandas
-  - pandoc
-  - numpy
-  - scipy
-  - jupyterlab
-  - ipython
-  - matplotlib
-  - scipy
-  - ipython
-  - dask
-  - pytest
-  - pytest-cov
-  - papermill
-  - click
-  - netcdf4
-  - h5netcdf
-  - zarr
-  - cftime
-  - bottleneck
-  - nc-time-axis
-  - jupyterlab_widgets
+  - pip==22.2.2
+  - xarray==2022.6.0
+  - pandas==1.4.3
+  - pandoc==2.19.2
+  - numpy==1.23.3
+  - scipy==1.9.1
+  - jupyterlab==3.4.7
+  - ipython==8.5.0
+  - matplotlib==3.5.3
+  - dask==2022.9.0
+  - pytest==7.1.3
+  - pytest-cov==3.0.0
+  - papermill==2.3.4
+  - click==8.1.3
+  - netcdf4==1.6.0
+  - h5netcdf==1.0.2
+  - zarr==2.12.0
+  - cftime==1.6.1
+  - bottleneck==1.3.5
+  - nc-time-axis==1.4.1
+  - jupyterlab_widgets==3.0.3
   - pip:
       - dscim==0.1.0
       - black==22.1.0
-      - flake8
-      - dill
-      - numbagg
-      - p_tqdm
+      - flake8==5.0.4
+      - dill==0.3.5.1
+      - numbagg==0.2.1
+      - p_tqdm==1.4.0
       - impactlab_tools==0.4.0
       - inquirer==2.10.0


### PR DESCRIPTION
This takes all the packages in `environment.yml` and pins them to their current versions.

This isn't a prefect, foolproof way to create a reproducible environment, but it's simple and a good start. We're not using tighter or more comprehensive environment.yml because this needs to be simple and run on different operating systems.
