### PR TITLE
Bump dscim to v0.2.0

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -29,7 +29,7 @@ dependencies:
   - nc-time-axis==1.4.1
   - jupyterlab_widgets==3.0.3
   - pip:
-      - dscim==0.1.0
+      - dscim==0.2.0
       - black==22.1.0
       - flake8==5.0.4
       - dill==0.3.5.1


### PR DESCRIPTION
This updates dscim from v0.1.0 -> v0.2.0.

This update should help remove loud logging messages, but otherwise just has internal dscim cleanup. So, we shouldn't expect breaks or changes otherwise.