### PR TITLE
Remove old badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-[![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
-
 # DSCIM: The Data-driven Spatial Climate Impact Model
 
 This Python library enables the calculation of sector-specific partial social cost of greenhouse gases (SC-GHG) and SCGHGs that are combined across sectors using a variety of valuation methods and assumptions. The main purpose of this


### PR DESCRIPTION
Removes the "black" badge. Most of our files are *not* formatted with `black`, unless y'all have just started doing that.